### PR TITLE
Don't force users to override style classes

### DIFF
--- a/src/Blazored.Toast/BlazoredToast.razor
+++ b/src/Blazored.Toast/BlazoredToast.razor
@@ -2,7 +2,7 @@
 
 @inherits BlazoredToastBase
 
-<div class="blazored-toast @ToastSettings.BaseClass @ToastSettings.AdditionalClasses">
+<div class="blazored-toast @ToastSettings.CssClasses">
     @if (!string.IsNullOrWhiteSpace(ToastSettings.IconClass))
     {
         <div class="blazored-toast-icon">

--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -48,16 +48,16 @@ namespace Blazored.Toast
             switch (level)
             {
                 case ToastLevel.Info:
-                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Info" : heading, message, "blazored-toast-info", InfoClass, InfoIconClass);
+                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Info" : heading, message, string.IsNullOrWhiteSpace(InfoClass) ? "blazored-toast-info" : InfoClass, InfoIconClass);
 
                 case ToastLevel.Success:
-                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Success" : heading, message, "blazored-toast-success", SuccessClass, SuccessIconClass);
+                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Success" : heading, message, string.IsNullOrWhiteSpace(SuccessClass) ? "blazored-toast-success" : SuccessClass, SuccessIconClass);
 
                 case ToastLevel.Warning:
-                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Warning" : heading, message, "blazored-toast-warning", WarningClass, WarningIconClass);
+                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Warning" : heading, message, string.IsNullOrWhiteSpace(WarningClass) ? "blazored-toast-warning" : WarningClass, WarningIconClass);
 
                 case ToastLevel.Error:
-                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Error" : heading, message, "blazored-toast-error", ErrorClass, ErrorIconClass);
+                    return new ToastSettings(string.IsNullOrWhiteSpace(heading) ? "Error" : heading, message, string.IsNullOrWhiteSpace(ErrorClass) ? "blazored-toast-error" : ErrorClass, ErrorIconClass);
             }
 
             throw new InvalidOperationException();

--- a/src/Blazored.Toast/Configuration/ToastSettings.cs
+++ b/src/Blazored.Toast/Configuration/ToastSettings.cs
@@ -2,19 +2,17 @@
 {
     public class ToastSettings
     {
-        public ToastSettings(string heading, string message, string baseClass, string additionalClasses, string iconClass)
+        public ToastSettings(string heading, string message, string cssClasses, string iconClass)
         {
             Heading = heading;
             Message = message;
-            BaseClass = baseClass;
-            AdditionalClasses = additionalClasses;
+            CssClasses = cssClasses;
             IconClass = iconClass;
         }
 
         public string Heading { get; set; }
         public string Message { get; set; }
-        public string BaseClass { get; set; }
-        public string AdditionalClasses { get; set; }
+        public string CssClasses { get; set; }
         public string IconClass { get; set; }
     }
 }

--- a/src/Blazored.Toast/wwwroot/blazored-toast.css
+++ b/src/Blazored.Toast/wwwroot/blazored-toast.css
@@ -23,26 +23,28 @@
     animation: fadein 1.5s;
     margin-bottom: 1rem;
     padding: 1rem 1.25rem;
-    color: #fff;
     width: 100vw;
-    font-family: monospace;
     box-shadow: rgba(0,0,0,0.25) 0px 10px 40px;
 }
 
 .blazored-toast-info {
-    background-color: #34a9ad;
+	background-color: #34a9ad;
+	color: #fff;
 }
 
 .blazored-toast-success {
-    background-color: #5fba7d;
+	background-color: #5fba7d;
+	color: #fff;
 }
 
 .blazored-toast-warning {
-    background-color: #c1c13e;
+	background-color: #c1c13e;
+	color: #fff;
 }
 
 .blazored-toast-error {
-    background-color: #ba5e5e;
+	background-color: #ba5e5e;
+	color: #fff;
 }
 
 .blazored-toast-icon {

--- a/src/Blazored.Toast/wwwroot/blazored-toast.css
+++ b/src/Blazored.Toast/wwwroot/blazored-toast.css
@@ -24,7 +24,7 @@
     margin-bottom: 1rem;
     padding: 1rem 1.25rem;
     width: 100vw;
-    box-shadow: rgba(0,0,0,0.25) 0px 10px 40px;
+    box-shadow: rgba(0,0,0,0.25) 0px 1px 4px;
 }
 
 .blazored-toast-info {

--- a/src/Blazored.Toast/wwwroot/blazored-toast.css
+++ b/src/Blazored.Toast/wwwroot/blazored-toast.css
@@ -69,7 +69,6 @@
 
         .blazored-toast-body .blazored-toast-header h5 {
             font-weight: bold;
-            text-transform: uppercase;
             font-size: 1.5rem;
             margin-bottom: 0;
             line-height: 32px;


### PR DESCRIPTION
- Don't use monospace as the font, this requires a consumer to override the internal base CSS structure. Inherit the font family.

- If a style is passed in, it should replace the blazor-toast-success, etc. class a consumer should not have to override it.

A consumer should be able to design their CSS selectors independent of this components internal structure or naming conventions, not against them.

Note that this change will be a breaking change for consumers that are overriding the different toast level calsses.