### PR TITLE
Remove explicit font family rule to inherit user defaults. Closes #43

### DIFF
--- a/src/Blazored.Toast/wwwroot/blazored-toast.css
+++ b/src/Blazored.Toast/wwwroot/blazored-toast.css
@@ -25,7 +25,6 @@
     padding: 1rem 1.25rem;
     color: #fff;
     width: 100vw;
-    font-family: monospace;
     box-shadow: rgba(0,0,0,0.25) 0px 10px 40px;
 }
 


### PR DESCRIPTION
Minor change, just removing explicit rule, so general rules from CSS apply.

Thanks!