### PR TITLE
added RenderFragment as option for toast messages

### DIFF
--- a/samples/BlazorClientSideSample/Pages/Index.razor
+++ b/samples/BlazorClientSideSample/Pages/Index.razor
@@ -7,3 +7,13 @@
 <button class="btn btn-success" @onclick="@(() => toastService.ShowSuccess("I'm a SUCCESS message with a custom heading", "Congratulations!"))">Success Toast</button>
 <button class="btn btn-warning" @onclick="@(() => toastService.ShowWarning("I'm a WARNING message"))">Warning Toast</button>
 <button class="btn btn-danger" @onclick="@(() => toastService.ShowError("I'm an ERROR message"))">Error Toast</button>
+<button class="btn btn-info" @onclick="@OnShowHtml">Info Toast with HTML</button>
+
+@code
+{
+    private void OnShowHtml()
+    {
+        RenderFragment message = @<text>Info Toast with <strong>bold</strong> text</text>;
+        toastService.ShowToast(ToastLevel.Info, message);
+    }
+}

--- a/samples/BlazorServerSideSample/Pages/Index.razor
+++ b/samples/BlazorServerSideSample/Pages/Index.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using Microsoft.AspNetCore.Components.Rendering
 @inject IToastService toastService
 
 <h1>Hello, Blazor Toast!</h1>
@@ -7,3 +8,13 @@
 <button class="btn btn-success" @onclick="@(() => toastService.ShowSuccess("I'm a SUCCESS message with a custom heading", "Congratulations!"))">Success Toast</button>
 <button class="btn btn-warning" @onclick="@(() => toastService.ShowWarning("I'm a WARNING message"))">Warning Toast</button>
 <button class="btn btn-danger" @onclick="@(() => toastService.ShowError("I'm an ERROR message"))">Error Toast</button>
+<button class="btn btn-info" @onclick="@OnShowHtml">Info Toast with HTML</button>
+
+@code
+{
+    private void OnShowHtml()
+    {
+        RenderFragment message = @<text>I'm an <em>INFO</em> message with some <strong>bold</strong> text</text>;
+        toastService.ShowToast(ToastLevel.Info, message);
+    }
+}

--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -43,7 +43,7 @@ namespace Blazored.Toast
             });
         }
 
-        private ToastSettings BuildToastSettings(ToastLevel level, string message, string heading)
+        private ToastSettings BuildToastSettings(ToastLevel level, RenderFragment message, string heading)
         {
             switch (level)
             {
@@ -63,7 +63,7 @@ namespace Blazored.Toast
             throw new InvalidOperationException();
         }
 
-        private void ShowToast(ToastLevel level, string message, string heading)
+        private void ShowToast(ToastLevel level, RenderFragment message, string heading)
         {
             InvokeAsync(() =>
             {

--- a/src/Blazored.Toast/Configuration/ToastSettings.cs
+++ b/src/Blazored.Toast/Configuration/ToastSettings.cs
@@ -1,8 +1,10 @@
-﻿namespace Blazored.Toast.Configuration
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Blazored.Toast.Configuration
 {
     public class ToastSettings
     {
-        public ToastSettings(string heading, string message, string baseClass, string additionalClasses, string iconClass)
+        public ToastSettings(string heading, RenderFragment message, string baseClass, string additionalClasses, string iconClass)
         {
             Heading = heading;
             Message = message;
@@ -12,7 +14,7 @@
         }
 
         public string Heading { get; set; }
-        public string Message { get; set; }
+        public RenderFragment Message { get; set; }
         public string BaseClass { get; set; }
         public string AdditionalClasses { get; set; }
         public string IconClass { get; set; }

--- a/src/Blazored.Toast/Services/IToastService.cs
+++ b/src/Blazored.Toast/Services/IToastService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.AspNetCore.Components;
 
 namespace Blazored.Toast.Services
 {
@@ -7,7 +8,7 @@ namespace Blazored.Toast.Services
         /// <summary>
         /// A event that will be invoked when showing a toast
         /// </summary>
-        event Action<ToastLevel, string, string> OnShow;
+        event Action<ToastLevel, RenderFragment, string> OnShow;
 
         /// <summary>
         /// Shows a information toast 
@@ -17,11 +18,25 @@ namespace Blazored.Toast.Services
         void ShowInfo(string message, string heading = "");
 
         /// <summary>
+        /// Shows a information toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        void ShowInfo(RenderFragment message, string heading = "");
+
+        /// <summary>
         /// Shows a success toast 
         /// </summary>
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         void ShowSuccess(string message, string heading = "");
+
+        /// <summary>
+        /// Shows a success toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        void ShowSuccess(RenderFragment message, string heading = "");
 
         /// <summary>
         /// Shows a warning toast 
@@ -31,11 +46,25 @@ namespace Blazored.Toast.Services
         void ShowWarning(string message, string heading = "");
 
         /// <summary>
+        /// Shows a warning toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        void ShowWarning(RenderFragment message, string heading = "");
+
+        /// <summary>
         /// Shows a error toast 
         /// </summary>
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         void ShowError(string message, string heading = "");
+
+        /// <summary>
+        /// Shows a error toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        void ShowError(RenderFragment message, string heading = "");
 
         /// <summary>
         /// Shows a toast using the supplied settings
@@ -44,5 +73,13 @@ namespace Blazored.Toast.Services
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         void ShowToast(ToastLevel level, string message, string heading = "");
+
+        /// <summary>
+        /// Shows a toast using the supplied settings
+        /// </summary>
+        /// <param name="level">Toast level to display</param>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        void ShowToast(ToastLevel level, RenderFragment message, string heading = "");
     }
 }

--- a/src/Blazored.Toast/Services/ToastService.cs
+++ b/src/Blazored.Toast/Services/ToastService.cs
@@ -1,15 +1,14 @@
 ﻿using System;
+using Microsoft.AspNetCore.Components;
 
 namespace Blazored.Toast.Services
 {
     public class ToastService : IToastService
     {
-        public ToastService() { }
-
         /// <summary>
         /// A event that will be invoked when showing a toast
         /// </summary>
-        public event Action<ToastLevel, string, string> OnShow;
+        public event Action<ToastLevel, RenderFragment, string> OnShow;
 
         /// <summary>
         /// Shows a information toast 
@@ -17,6 +16,16 @@ namespace Blazored.Toast.Services
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         public void ShowInfo(string message, string heading = "")
+        {
+            ShowToast(ToastLevel.Info, message, heading);
+        }
+
+        /// <summary>
+        /// Shows a information toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        public void ShowInfo(RenderFragment message, string heading = "")
         {
             ShowToast(ToastLevel.Info, message, heading);
         }
@@ -32,11 +41,31 @@ namespace Blazored.Toast.Services
         }
 
         /// <summary>
+        /// Shows a success toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        public void ShowSuccess(RenderFragment message, string heading = "")
+        {
+            ShowToast(ToastLevel.Success, message, heading);
+        }
+
+        /// <summary>
         /// Shows a warning toast 
         /// </summary>
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         public void ShowWarning(string message, string heading = "")
+        {
+            ShowToast(ToastLevel.Warning, message, heading);
+        }
+
+        /// <summary>
+        /// Shows a warning toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        public void ShowWarning(RenderFragment message, string heading = "")
         {
             ShowToast(ToastLevel.Warning, message, heading);
         }
@@ -52,12 +81,34 @@ namespace Blazored.Toast.Services
         }
 
         /// <summary>
+        /// Shows a error toast 
+        /// </summary>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        public void ShowError(RenderFragment message, string heading = "")
+        {
+            ShowToast(ToastLevel.Error, message, heading);
+        }
+
+        /// <summary>
         /// Shows a toast using the supplied settings
         /// </summary>
         /// <param name="level">Toast level to display</param>
         /// <param name="message">Text to display on the toast</param>
         /// <param name="heading">The text to display as the toasts heading</param>
         public void ShowToast(ToastLevel level, string message, string heading = "")
+        {
+            ShowToast(level, builder => builder.AddContent(0, message), heading);
+        }
+
+
+        /// <summary>
+        /// Shows a toast using the supplied settings
+        /// </summary>
+        /// <param name="level">Toast level to display</param>
+        /// <param name="message">RenderFragment to display on the toast</param>
+        /// <param name="heading">The text to display as the toasts heading</param>
+        public void ShowToast(ToastLevel level, RenderFragment message, string heading = "")
         {
             OnShow?.Invoke(level, message, heading);
         }


### PR DESCRIPTION
This PR adds overloads to `IToastService` which accept `RenderFragment`s instead of `string`s. This enables the user to display HTML in the toast message. I've extended both BlazorClientSideSample and BlazorServerSideSample to demo it.

Fixes #49 