### PR TITLE
Moved the toast timer to the toast instance

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 3.1.101
+    version: 3.1.201
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: NuGetToolInstaller@0

--- a/src/Blazored.Toast/BlazoredToast.razor.cs
+++ b/src/Blazored.Toast/BlazoredToast.razor.cs
@@ -1,19 +1,37 @@
 ﻿using Blazored.Toast.Configuration;
 using Microsoft.AspNetCore.Components;
 using System;
+using System.Timers;
 
 namespace Blazored.Toast
 {
-    public partial class BlazoredToast
+    public partial class BlazoredToast : IDisposable
     {
         [CascadingParameter] private BlazoredToasts ToastsContainer { get; set; }
 
         [Parameter] public Guid ToastId { get; set; }
         [Parameter] public ToastSettings ToastSettings { get; set; }
+        [Parameter] public int Timeout { get; set; }
+
+        private Timer _timer;
+
+        protected override void OnInitialized()
+        {
+            _timer = new Timer(Timeout * 1000);
+            _timer.Elapsed += (sender, args) => { Close(); };
+            _timer.AutoReset = false;
+            _timer.Start();
+        }
 
         private void Close()
         {
             ToastsContainer.RemoveToast(ToastId);
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
+            _timer = null;
         }
     }
 }

--- a/src/Blazored.Toast/BlazoredToasts.razor
+++ b/src/Blazored.Toast/BlazoredToasts.razor
@@ -4,7 +4,7 @@
         <CascadingValue Value=this>
             @foreach (var toast in ToastList.OrderBy(x=>x.TimeStamp))
             {
-                <BlazoredToast ToastSettings="toast.ToastSettings" ToastId="toast.Id" />
+                <BlazoredToast @key="toast" ToastSettings="toast.ToastSettings" ToastId="toast.Id" Timeout="Timeout" />
             }
         </CascadingValue>
     </div>

--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -27,7 +27,6 @@ namespace Blazored.Toast
         [Parameter] public string ErrorIcon { get; set; }
         [Parameter] public ToastPosition Position { get; set; } = ToastPosition.TopRight;
         [Parameter] public int Timeout { get; set; } = 5;
-        [Parameter] public bool RemoveToastsOnNavigation { get; set; }
 
         private string PositionClass { get; set; } = string.Empty;
         internal List<ToastInstance> ToastList { get; set; } = new List<ToastInstance>();
@@ -35,11 +34,6 @@ namespace Blazored.Toast
         protected override void OnInitialized()
         {
             ToastService.OnShow += ShowToast;
-
-            if (RemoveToastsOnNavigation)
-            {
-                NavigationManager.LocationChanged += ClearToasts;
-            }
 
             PositionClass = $"position-{Position.ToString().ToLower()}";
 
@@ -59,15 +53,6 @@ namespace Blazored.Toast
             {
                 var toastInstance = ToastList.SingleOrDefault(x => x.Id == toastId);
                 ToastList.Remove(toastInstance);
-                StateHasChanged();
-            });
-        }
-
-        private void ClearToasts(object sender, LocationChangedEventArgs args)
-        {
-            InvokeAsync(() =>
-            {
-                ToastList.Clear();
                 StateHasChanged();
             });
         }


### PR DESCRIPTION
This Pr moves the timers to the toast instances. This means we can do things better, like properly dispose of the timer instances. It also enables us to add features like #57. 