### PR TITLE
Added possibility to define custom close icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Toasts are configured using parameters on the `<BlazoredToasts />` component. Th
 - IconType (Default: IconType.FontAwesome)
 - Position (Default: ToastPosition.TopRight)
 - Timeout (Default: 5)
+- ShowProgressBar (Default: false)
+- ShowCloseButton (Default: true)
+- CloseButtonContent (provide custom close button)
 
 By default, you don't need to provide any settings everything will just work. But if you want to add icons to toasts or override the default styling then you can use the options above to do that. 
 
@@ -98,6 +101,18 @@ The example above is from the [client side samples](https://github.com/Blazored/
 ```
 The example above is from the [server side samples](https://github.com/Blazored/Toast/tree/master/samples) and demonstrates the use of Material Design icons.
 
+
+If you want to have your own custom close button:
+```html
+<BlazoredToasts Position="ToastPosition.BottomRight"
+                Timeout="10">
+    <CloseButtonContent>
+        <div>
+            <span>&times;</span>
+        </div>
+    </CloseButtonContent>
+</BlazoredToasts>
+```
 
 ### 4. Add reference to style sheet(s)
 Add the following line to the `head` tag of your `_Host.cshtml` (Blazor Server app) or `index.html` (Blazor WebAssembly).

--- a/samples/BlazorServer/Shared/MainLayout.razor
+++ b/samples/BlazorServer/Shared/MainLayout.razor
@@ -8,7 +8,14 @@
                 InfoIcon="school"
                 SuccessIcon="done_outline"
                 WarningIcon="warning"
-                ShowProgressBar="@true"/>
+                ShowProgressBar="@true"
+                ShowCloseButton="@true">
+    <CloseButtonContent>
+        <div>
+            <span class="myCloseButtonStyleClass">&times;</span>
+        </div>
+    </CloseButtonContent>
+</BlazoredToasts>
 
 <div class="sidebar">
     <NavMenu />

--- a/src/Blazored.Toast/BlazoredToast.razor
+++ b/src/Blazored.Toast/BlazoredToast.razor
@@ -19,21 +19,24 @@
     <div class="blazored-toast-body">
         <div class="blazored-toast-header">
             <h5 class="blazored-toast-heading">@ToastSettings.Heading</h5>
-            <button class="blazored-toast-close" @onclick=@Close>
-                <i aria-label="icon: close" class="blazored-toast-close-icon">
-                    @if (CloseButtonContent != null)
-                    {
-                        @CloseButtonContent
-                    }
-                    else
-                    {
+            @if (ShowCloseButton)
+            {
+                <button class="blazored-toast-close" @onclick=@Close>
+                    <i aria-label="icon: close" class="blazored-toast-close-icon">
+                        @if (CloseButtonContent != null)
+                        {
+                            @CloseButtonContent
+                        }
+                        else
+                        {
                         <svg viewBox="64 64 896 896" focusable="false" width="1em" height="1em" fill="currentColor" aria-hidden="true">
                             <path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z">
                             </path>
                         </svg>
-                    }
-                </i>
-            </button>
+                        }
+                    </i>
+                </button>
+            }
         </div>
         <p class="blazored-toast-message">@ToastSettings.Message</p>
     </div>

--- a/src/Blazored.Toast/BlazoredToast.razor
+++ b/src/Blazored.Toast/BlazoredToast.razor
@@ -21,10 +21,17 @@
             <h5 class="blazored-toast-heading">@ToastSettings.Heading</h5>
             <button class="blazored-toast-close" @onclick=@Close>
                 <i aria-label="icon: close" class="blazored-toast-close-icon">
-                    <svg viewBox="64 64 896 896" focusable="false" width="1em" height="1em" fill="currentColor" aria-hidden="true">
-                        <path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z">
-                        </path>
-                    </svg>
+                    @if (CloseButtonContent != null)
+                    {
+                        @CloseButtonContent
+                    }
+                    else
+                    {
+                        <svg viewBox="64 64 896 896" focusable="false" width="1em" height="1em" fill="currentColor" aria-hidden="true">
+                            <path d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 0 0 203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z">
+                            </path>
+                        </svg>
+                    }
                 </i>
             </button>
         </div>

--- a/src/Blazored.Toast/BlazoredToast.razor.cs
+++ b/src/Blazored.Toast/BlazoredToast.razor.cs
@@ -13,6 +13,7 @@ namespace Blazored.Toast
         [Parameter] public ToastSettings ToastSettings { get; set; }
         [Parameter] public int Timeout { get; set; }
         private RenderFragment CloseButtonContent => ToastsContainer.CloseButtonContent;
+        private bool ShowCloseButton => ToastsContainer.ShowCloseButton;
 
         private CountdownTimer _countdownTimer;
         private int _progress = 100;

--- a/src/Blazored.Toast/BlazoredToast.razor.cs
+++ b/src/Blazored.Toast/BlazoredToast.razor.cs
@@ -12,6 +12,7 @@ namespace Blazored.Toast
         [Parameter] public Guid ToastId { get; set; }
         [Parameter] public ToastSettings ToastSettings { get; set; }
         [Parameter] public int Timeout { get; set; }
+        private RenderFragment CloseButtonContent => ToastsContainer.CloseButtonContent;
 
         private CountdownTimer _countdownTimer;
         private int _progress = 100;
@@ -20,7 +21,7 @@ namespace Blazored.Toast
         {
             _countdownTimer = new CountdownTimer(Timeout);
             _countdownTimer.OnTick += CalculateProgress;
-            _countdownTimer.OnElapsed += () => { Close(); };
+            _countdownTimer.OnElapsed += Close;
             _countdownTimer.Start();
 
         }

--- a/src/Blazored.Toast/BlazoredToasts.razor
+++ b/src/Blazored.Toast/BlazoredToasts.razor
@@ -1,7 +1,7 @@
 ﻿@if (ToastList.Any())
 {
     <div class="blazored-toast-container @PositionClass">
-        <CascadingValue Value=this>
+        <CascadingValue Value=this IsFixed="true">
             @foreach (var toast in ToastList.OrderBy(x=>x.TimeStamp))
             {
                 <BlazoredToast @key="toast" ToastSettings="toast.ToastSettings" ToastId="toast.Id" Timeout="Timeout"/>

--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -31,9 +31,10 @@ namespace Blazored.Toast
         [Parameter] public bool RemoveToastsOnNavigation { get; set; }
         [Parameter] public bool ShowProgressBar { get; set; }
         [Parameter] public RenderFragment CloseButtonContent { get; set; }
+        [Parameter] public bool ShowCloseButton { get; set; } = true;
 
         private string PositionClass { get; set; } = string.Empty;
-        internal List<ToastInstance> ToastList { get; set; } = new List<ToastInstance>();
+        private List<ToastInstance> ToastList { get; set; } = new List<ToastInstance>();
 
         protected override void OnInitialized()
         {

--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Timers;
+using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Blazored.Toast
 {
@@ -29,6 +30,7 @@ namespace Blazored.Toast
         [Parameter] public int Timeout { get; set; } = 5;
         [Parameter] public bool RemoveToastsOnNavigation { get; set; }
         [Parameter] public bool ShowProgressBar { get; set; }
+        [Parameter] public RenderFragment CloseButtonContent { get; set; }
 
         private string PositionClass { get; set; } = string.Empty;
         internal List<ToastInstance> ToastList { get; set; } = new List<ToastInstance>();


### PR DESCRIPTION
Essentially closes #98 

This will give the option to define a custom close button. The implementation still uses the current approach as default. Therefore a custom icon is completely optional.

## Usage
The definition of the custom icon will be as `RenderFragment` for the  `BlazoredToasts` component.
For Blazor server in _Host.cshtml / for Blazor Webassembly in MainLayout.razor:

```csharp
<BlazoredToasts Position="ToastPosition.BottomRight"
                Timeout="10"
                IconType="IconType.Material"
                ErrorIcon="error_outline"
                InfoIcon="school"
                SuccessIcon="done_outline"
                WarningIcon="warning"
                ShowProgressBar="@true">
    <CloseButtonContent>
        <img src="https://media.istockphoto.com/vectors/close-thin-line-vector-icon-vector-id857112152?k=6&m=857112152&s=612x612&w=0&h=py-FFtgw7ta7FGHGM71HBehuksNs2bRSHhudMAOI3qw="
             width="32" height="32" alt="close"/>
    </CloseButtonContent>
</BlazoredToasts>
````
Will become: ![close button](https://i.imgur.com/ivcm8Xr.png)

I also added `IsFixed` to the ParentComponent (`BlazoredToasts`) as the child component (`BlazoredToast`) is not relying on updates. 