### PR TITLE
Do not call StateHasChanged on progress when ProgressBar is not in use

### DIFF
--- a/src/Blazored.Toast/BlazoredToast.razor.cs
+++ b/src/Blazored.Toast/BlazoredToast.razor.cs
@@ -32,7 +32,10 @@ public partial class BlazoredToast : IDisposable
     private async Task CalculateProgressAsync(int percentComplete)
     {
         _progress = 100 - percentComplete;
-        await InvokeAsync(StateHasChanged);
+        if (_progress == 0 || (ToastSettings?.ShowProgressBar ?? false))
+        {
+            await InvokeAsync(StateHasChanged);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
When not showing the Progress Bar there is no need to call StateHasChanged.

This is particularly necessary when using Server side rendering, to prevent 100 messages from Server to Client that will be anyways ignored by the client.