### PR TITLE
251 - Fix null reference exception in OnInitializedAsync

### DIFF
--- a/src/Blazored.Toast/BlazoredToasts.razor.cs
+++ b/src/Blazored.Toast/BlazoredToasts.razor.cs
@@ -67,6 +67,7 @@ public partial class BlazoredToasts
         instanceToastSettings.PauseProgressOnHover ??= PauseProgressOnHover;
         instanceToastSettings.ExtendedTimeout ??= ExtendedTimeout;
         instanceToastSettings.Position ??= Position;
+        instanceToastSettings.ShowProgressBar ??= ShowProgressBar;
 
         return instanceToastSettings;
     }


### PR DESCRIPTION
Resolves: https://github.com/Blazored/Toast/issues/251

This issue can be recreated by using the `ShowToast<TComponent>` method where `ToastSettings` is not a parameter. This method sets `ToastSettings` to null which resulted in `ShowProgressBar` also being null. According to [this line](https://github.com/Blazored/Toast/blob/21a1fa5a898f6558cef9fe9b90b052e0131d3dcd/src/Blazored.Toast/BlazoredToast.razor.cs#L31C9-L31C12), `ShowProgressBar` cannot be null. 

We are now handling this similarly to how we handle the other parameters in `ToastSettings`.

We are unable to add test coverage for this change with the current infrastructure as we would need to render a toast message.